### PR TITLE
Listen Redis and MongoDB locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   mongo:
     image: mongo:latest
     ports:
-        - 27017:27017
+      - "127.0.0.1:27017:27017"
     volumes:
-        - ~/dplayer/db:/data/db
+      - ~/dplayer/db:/data/db
   redis:
     image: redis:latest
     ports:
-        - "6379:6379"
+      - "127.0.0.1:6379:6379"
   web:
     build: .
     links:


### PR DESCRIPTION
In `docker-compose.yml`, if not specified, the port would be bind for 0.0.0.0, which would be exposed to public. For Redis and MongoDB, they are for local use and should not become public. Moreover, no password is set for them, thus they can be vulnerable and may cause serious security problems.