### PR TITLE
using pm2 new version(5.x) occurs error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:8-onbuild
 WORKDIR /usr/src/app
-RUN npm install pm2 -g
+RUN npm install pm2@3.5.1 -g
 EXPOSE 1207
 CMD pm2-docker index.js


### PR DESCRIPTION
The Dockerfile dons't using a fixed version of pm2, RUN npm install pm2 is 5.x now, it throws the flowing error:

```
  | /usr/local/lib/node_modules/pm2/lib/ProcessContainerFork.js:30
web_1    |     import(url.pathToFileURL(process.env.pm_exec_path));
```
it pass when I set it with `RUN npm install pm2@3.5.1 -g`, the latest version about three years ago, as the same time of the latest commit of this project.