### PR TITLE
remove attribute `version` in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   mongo:
     image: mongo:latest


### PR DESCRIPTION
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion